### PR TITLE
Add log_to option: logfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![RailsJazz](https://github.com/igorkasyanchuk/rails_time_travel/blob/main/docs/my_other.svg?raw=true)](https://www.railsjazz.com)
 [![https://www.patreon.com/igorkasyanchuk](https://github.com/igorkasyanchuk/rails_time_travel/blob/main/docs/patron.svg?raw=true)](https://www.patreon.com/igorkasyanchuk)
 
-How usually you debug your code? Binding.pry, byebug, puts, ... 
+How usually you debug your code? Binding.pry, byebug, puts, ...
 
 How ofter do you write a code something like:
 
@@ -13,7 +13,7 @@ puts current_user.full_name
 puts "="*50
 ```
 
-I do this at least few times per week, sometimes per day. 
+I do this at least few times per week, sometimes per day.
 
 This is annoying. It's need to be automated. And this gem is a simple solution.
 
@@ -58,6 +58,7 @@ You can do a simple configuration to the gem (config/initializers/wrapped_print.
 WrappedPrint.setup do |config|
   # config.log_to = :console # simply puts
   config.log_to = :logs # e.g. Rails.logger.info....
+  # config.log_to = ActiveSupport::Logger.new($stdout) # custom logger
 
   # # applicable only for Logger (not console)
   config.level = :debug
@@ -84,7 +85,7 @@ or
 ```ruby
 #
 # see how .wp is called. This method `.wp` returning the original value, so you can use it as normal variable.
-# 
+#
 class A
   def calc
     z = balance.wp # same as z = balance

--- a/lib/wrapped_print.rb
+++ b/lib/wrapped_print.rb
@@ -4,10 +4,7 @@ require "active_support"
 # WrappedPrint.setup do |config|
   # config.log_to = :console # simply puts
   # config.log_to = :logs # e.g. Rails.logger.info....
-  # config.log_to = :custom
-
-  # # set up custom logger (optional, default is Logger.new("#{Rails.root}/log/wrapped_print.log"))
-  # config.custom_logger = ActiveSupport::Logger.new("#{Rails.root}/log/wrapped_print.log"))
+  # config.log_to = ActiveSupport::Logger.new("#{Rails.root}/log/wrapped_print.log") # custom logger
 
   # # applicable only for Logger (not console)
   # config.level = :debug
@@ -17,9 +14,6 @@ require "active_support"
 module WrappedPrint
   mattr_accessor :log_to
   @@log_to = :console
-
-  mattr_accessor :custom_logger
-  @@custom_logger = ActiveSupport::Logger.new("log/wrapped_print.log")
 
   mattr_accessor :level
   @@level = :debug
@@ -58,14 +52,11 @@ module WrappedPrint
 
     private
     def detect_logger_method
+      return WrappedPrint.log_to.method(WrappedPrint.level) if WrappedPrint.log_to.is_a?(ActiveSupport::Logger)
+
       case WrappedPrint.log_to
       when :logs
         Rails.logger.method(WrappedPrint.level)
-      when :custom
-        unless WrappedPrint.custom_logger&.respond_to?(WrappedPrint.level)
-          @@custom_logger = ActiveSupport::Logger.new("log/wrapped_print.log")
-        end
-        WrappedPrint.custom_logger.method(WrappedPrint.level)
       else
         method(:puts)
       end

--- a/lib/wrapped_print.rb
+++ b/lib/wrapped_print.rb
@@ -4,6 +4,10 @@ require "active_support"
 # WrappedPrint.setup do |config|
   # config.log_to = :console # simply puts
   # config.log_to = :logs # e.g. Rails.logger.info....
+  # config.log_to = :custom
+
+  # # set up custom logger (optional, default is Logger.new("#{Rails.root}/log/wrapped_print.log"))
+  # config.custom_logger = ActiveSupport::Logger.new("#{Rails.root}/log/wrapped_print.log"))
 
   # # applicable only for Logger (not console)
   # config.level = :debug
@@ -13,6 +17,9 @@ require "active_support"
 module WrappedPrint
   mattr_accessor :log_to
   @@log_to = :console
+
+  mattr_accessor :custom_logger
+  @@custom_logger = ActiveSupport::Logger.new("log/wrapped_print.log")
 
   mattr_accessor :level
   @@level = :debug
@@ -51,8 +58,14 @@ module WrappedPrint
 
     private
     def detect_logger_method
-      if WrappedPrint.log_to == :logs
+      case WrappedPrint.log_to
+      when :logs
         Rails.logger.method(WrappedPrint.level)
+      when :custom
+        unless WrappedPrint.custom_logger&.respond_to?(WrappedPrint.level)
+          @@custom_logger = ActiveSupport::Logger.new("log/wrapped_print.log")
+        end
+        WrappedPrint.custom_logger.method(WrappedPrint.level)
       else
         method(:puts)
       end

--- a/spec/wrapped_print_spec.rb
+++ b/spec/wrapped_print_spec.rb
@@ -14,6 +14,25 @@ RSpec.describe WrappedPrint do
     expect(WrappedPrint::VERSION).not_to be nil
   end
 
+  it "writes to a custom logger" do
+    logger_io = StringIO.new
+
+    WrappedPrint.setup do |config|
+      config.log_to = :custom
+      config.custom_logger = ActiveSupport::Logger.new(logger_io)
+    end
+
+    expect("Hello".wp).to eq("Hello")
+
+    expected_log = <<~LOG
+    --------------------------------------------------------------------------------
+    Hello
+    --------------------------------------------------------------------------------
+    LOG
+
+    expect(logger_io.string).to eq(expected_log)
+  end
+
   it "does something useful" do
     expect("Hello".wp).to eq("Hello")
     expect(wp { "World" }).to eq("World")

--- a/spec/wrapped_print_spec.rb
+++ b/spec/wrapped_print_spec.rb
@@ -18,8 +18,7 @@ RSpec.describe WrappedPrint do
     logger_io = StringIO.new
 
     WrappedPrint.setup do |config|
-      config.log_to = :custom
-      config.custom_logger = ActiveSupport::Logger.new(logger_io)
+      config.log_to = ActiveSupport::Logger.new(logger_io)
     end
 
     expect("Hello".wp).to eq("Hello")


### PR DESCRIPTION
First, let me thank you for this gem. It's awesome!

I added the option to send the logs to a specific `wrapped_print.log` file by using the `log_to: :logfile`. This is very useful for me and perhaps others will appreciate it as well.

Thanks!

Eric